### PR TITLE
Hengle/refactor auth

### DIFF
--- a/spec/test_pg.cr
+++ b/spec/test_pg.cr
@@ -24,10 +24,6 @@ class User < Crecto::Model
     field :first_posted, Time
     field :last_posted, Time
   end
-
-  def password_valid?(password : String)
-    Crypto::Bcrypt::Password.new(@encrypted_password.not_nil!) == password
-  end
 end
 
 class Post < Crecto::Model
@@ -41,18 +37,10 @@ end
 admin_resource(User, Repo)
 admin_resource(Post, Repo)
 
-# CrectoAdmin.config do |c|
-#  c.auth = CrectoAdmin::DatabaseAuth
-#  c.auth_model = User
-#  c.auth_model_identifier = :email
-#  c.auth_method = ->(email : String, password : String) {
-#    user = Repo.get_by!(User, email: email)
-#    user.password_valid?(password)
-#  }
-# end
-
-Kemal::Session.config do |config|
-  config.secret = "my_super_secret"
+CrectoAdmin.config do |c|
+  c.auth_repo = Repo
+  c.auth_model = User
 end
+
 # Right now Crystal Admin is using kemal to render views
 Kemal.run

--- a/spec/test_pg.cr
+++ b/spec/test_pg.cr
@@ -40,6 +40,12 @@ admin_resource(Post, Repo)
 CrectoAdmin.config do |c|
   c.auth_repo = Repo
   c.auth_model = User
+  c.auth_model_identifier = :email
+  c.auth_model_password = :encrypted_password
+end
+
+Kemal::Session.config do |config|
+  config.secret = "my super secret"
 end
 
 # Right now Crystal Admin is using kemal to render views

--- a/src/CrectoAdmin/config.cr
+++ b/src/CrectoAdmin/config.cr
@@ -3,9 +3,25 @@ module CrectoAdmin
     INSTANCE = Config.new
 
     property auth : String?
+    property auth_repo : (Crecto::Repo)?
     property auth_model : (Crecto::Model.class)?
     property auth_model_identifier : Symbol?
+    property auth_model_password : Symbol?
     property auth_method : Proc(String, String, Bool)?
+
+    def initialize
+      @auth = CrectoAdmin::DatabaseAuth
+      @auth_model_identifier = :email
+      @auth_model_password = :encrypted_password
+      @auth_method = ->(user_id : String, password : String) {
+        query = Crecto::Repo::Query.where(@auth_model_identifier.not_nil!, user_id).limit(1)
+        users = @auth_repo.not_nil!.all(@auth_model.not_nil!, query)
+        return false unless users.size == 1
+        user = users.first
+        encrypted_password = user.to_query_hash[@auth_model_password.not_nil!].to_s
+        Crypto::Bcrypt::Password.new(encrypted_password) == password
+      }
+    end
   end
 
   def self.config

--- a/src/CrectoAdmin/config.cr
+++ b/src/CrectoAdmin/config.cr
@@ -2,24 +2,27 @@ module CrectoAdmin
   class Config
     INSTANCE = Config.new
 
+    property auth_enabled : Bool
     property auth : String?
     property auth_repo : (Crecto::Repo)?
     property auth_model : (Crecto::Model.class)?
     property auth_model_identifier : Symbol?
     property auth_model_password : Symbol?
-    property auth_method : Proc(String, String, Bool)?
+    property auth_method : Proc(String, String, String)?
 
     def initialize
+      @auth_enabled = true
       @auth = CrectoAdmin::DatabaseAuth
       @auth_model_identifier = :email
       @auth_model_password = :encrypted_password
-      @auth_method = ->(user_id : String, password : String) {
-        query = Crecto::Repo::Query.where(@auth_model_identifier.not_nil!, user_id).limit(1)
+      @auth_method = ->(user_identifier : String, password : String) {
+        query = Crecto::Repo::Query.where(@auth_model_identifier.not_nil!, user_identifier).limit(1)
         users = @auth_repo.not_nil!.all(@auth_model.not_nil!, query)
-        return false unless users.size == 1
+        return "" unless users.size == 1
         user = users.first
         encrypted_password = user.to_query_hash[@auth_model_password.not_nil!].to_s
-        Crypto::Bcrypt::Password.new(encrypted_password) == password
+        return "" unless Crypto::Bcrypt::Password.new(encrypted_password) == password
+        return user_identifier
       }
     end
   end

--- a/src/CrectoAdmin/views/admin_layout.ecr
+++ b/src/CrectoAdmin/views/admin_layout.ecr
@@ -25,9 +25,9 @@
         </div>
         <div class="navbar-menu is-active">
           <div class="navbar-end">
-            <% if CrectoAdmin.admin_signed_in?(ctx) && CrectoAdmin.config.auth %>
+            <% if CrectoAdmin.admin_signed_in?(ctx) && CrectoAdmin.config.auth_enabled %>
               <a class="navbar-item">
-                Signed in as <%= CrectoAdmin.current_user(ctx).to_query_hash[CrectoAdmin.config.auth_model_identifier.not_nil!] %>
+                Signed in as <%= CrectoAdmin.current_user(ctx) %>
               </a>
               <div class="navbar-item">
                 <div class="field is-grouped">

--- a/src/CrectoAdmin/views/sign_in.ecr
+++ b/src/CrectoAdmin/views/sign_in.ecr
@@ -3,12 +3,12 @@
     <input type="hidden" name="authenticity_token" value="<%= ctx.session.string("csrf") %>" />
 
     <div class="field">
+      <% user_label = CrectoAdmin.config.auth_model_identifier.nil? ? "user" : CrectoAdmin.config.auth_model_identifier %>
       <label class="label" style="text-transform:capitalize;">
-        <%= CrectoAdmin.config.auth_model_identifier.not_nil!.to_s %>
+        <%= user_label %>
       </label>
       <div class="control has-icons-left">
-        <input class="input" type="text" name="<%= CrectoAdmin.config.auth_model_identifier.not_nil!.to_s %>"
-          placeholder="<%= CrectoAdmin.config.auth_model_identifier.not_nil!.to_s %>">
+        <input class="input" type="text" name="user" placeholder="<%= user_label %>">
         <span class="icon is-small is-left">
           <i class="fas fa-user"></i>
         </span>


### PR DESCRIPTION
I refactored the auth code a bit. Initially, just added a default auth_method to the config instance so that a user does not need to specify the method, but instead specify the model identifier and encrypted password fields to use the auth function. Then, I tried to make the auth more generic that, without declaring any auth model, a user could just specify the auth_method(return a user id) to make the auth working. That's why I made a bit more changes. Not sure if it is valid or not.

In addition, specifying the encrypted password field could help to implement another feature that is setting an encrypted password with a normal password in the new/update user form, which I would like to implement the next.
